### PR TITLE
Fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ requests_toolbelt
 networkx==1.11
 urllib3>=1.16
 pandas
-networkx
+enum34
+pysolr

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,8 @@ if __name__ == '__main__':
             'networkx==1.11',
             'urllib3>=1.16',
             'pandas',
-            'networkx'
+            'enum34',
+            'pysolr'
         ],
 
         include_package_data=True


### PR DESCRIPTION
This PR fixes a redundant requirement for networkx (causes error when doing pip install -r) and adds two missing requirements to the list.