### PR TITLE
Adding Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.7"
   - "3.5"
 install:
-  - python setup.py install
+  - pip install -r requirements.txt
 script:
+  - export PYTHONPATH=$PYTHONPATH:$TRAVIS_BUILD_DIR
   - nosetests tests -v --with-coverage --cover-inclusive --cover-package=ndex2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   - pip install coverage
 script:
   - export PYTHONPATH=$PYTHONPATH:$TRAVIS_BUILD_DIR
-  - nosetests tests -v --with-coverage --cover-inclusive --cover-package=ndex2
+  - nosetests -v --with-coverage --cover-inclusive --cover-package=ndex2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   - pip install coverage
 script:
   - export PYTHONPATH=$PYTHONPATH:$TRAVIS_BUILD_DIR
-  - nosetests -v --with-coverage --cover-inclusive --cover-package=ndex2
+  - nosetests -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+install:
+  - python setup.py install
+script:
+  - nosetests tests -v --with-coverage --cover-inclusive --cover-package=ndex2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.5"
 install:
   - pip install -r requirements.txt
+  - pip install coverage
 script:
   - export PYTHONPATH=$PYTHONPATH:$TRAVIS_BUILD_DIR
   - nosetests tests -v --with-coverage --cover-inclusive --cover-package=ndex2

--- a/export_to_csv.py
+++ b/export_to_csv.py
@@ -19,5 +19,5 @@ my_pd = niceCx.to_pandas_dataframe()
 #=====================
 my_pd.to_csv('CXExport.csv', sep=',')
 
-print 'Done'
+print('Done')
 

--- a/ndex2/networkn.py
+++ b/ndex2/networkn.py
@@ -406,7 +406,7 @@ class NdexGraph (MultiDiGraph):
                 self.unclassified_cx.append(aspect)
             else:
                 self.unclassified_cx.append(aspect)
-        print ''
+        print('')
 
     def networkx_to_NdexGraph(networkx_G):
         """Converts a NetworkX into a NdexGraph object"""
@@ -1073,11 +1073,11 @@ class NdexGraph (MultiDiGraph):
             try:
                 return_bytes = io.BytesIO(json.dumps(cx))
             except UnicodeDecodeError as err1:
-                print "Detected invalid encoding. Trying latin-1 encoding."
+                print("Detected invalid encoding. Trying latin-1 encoding.")
                 return_bytes = io.BytesIO(json.dumps(cx, encoding="latin-1"))
-                print "Success"
+                print("Success")
             except Exception as err2:
-                print err2.message
+                print(err2.message)
 
             return return_bytes
 

--- a/ndex2/test/scratchtests.py
+++ b/ndex2/test/scratchtests.py
@@ -26,7 +26,7 @@ def test_set_edge_attribute():
     #network_id = G.upload_to("http://dev.ndexbio.org", "scratch", "scratch")
     #print(network_id)
 
-    print G.to_cx()
+    print(G.to_cx())
 
 def test_create_from_edge_list():
     G = NdexGraph()
@@ -41,7 +41,7 @@ def test_create_from_edge_list():
     network_id = G.upload_to("http://dev.ndexbio.org", "scratch", "scratch")
     print(network_id)
 
-    print G.to_cx()
+    print(G.to_cx())
 
     #ndex = Ndex("http://dev.ndexbio.org", "scratch", "scratch")
     #ndex.make_network_public(network_id)
@@ -97,7 +97,7 @@ def test_layout():
 
 def test_filter_sub():
     repo_directory = '/Users/aarongary/Development/DataSets/NDEx/server2/data/'
-    print inspect.getfile(FilterSub)
+    print(inspect.getfile(FilterSub))
     read_this_aspect = os.path.join(repo_directory, 'NCI_Style.cx') #'Diffusion1.cx') #'subnetwork_ex1.cx')
 
     with open(read_this_aspect, 'rt') as fid:
@@ -105,7 +105,7 @@ def test_filter_sub():
         if(data is not None):
             my_filter_sub = FilterSub(data, subnet_index=0)
             ndexGraph = NdexGraph(my_filter_sub.get_cx())
-            print ndexGraph.to_cx()
+            print(ndexGraph.to_cx())
 
 
 def scratch_test():

--- a/ndex2/test/test_NetworkNConstructor.py
+++ b/ndex2/test/test_NetworkNConstructor.py
@@ -29,7 +29,7 @@ class NetworkNConstructorTests(unittest.TestCase):
             self.assertEqual(len(G.context),39)'''
 
             G.update_to('b8fedefb-29e5-11e7-b3a1-06832d634f41', 'http://dev.ndexbio.org', 'scratch', 'scratch')
-        print "done"
+        print("done")
 
     def test2(self):
         with open (path.join(HERE,'filtered.cx'),'r') as cx_file:

--- a/ndex2/test/test_networkn.py
+++ b/ndex2/test/test_networkn.py
@@ -51,7 +51,7 @@ class NetworkNTests(unittest.TestCase):
         e_4 = G.add_edge(n_b, n_c, 13, {'weight': 2.011})
         e_5 = G.add_edge(n_b, n_d, 14, {'weight': 7.788})
 
-        print json.dumps(G.to_cx())
+        print(json.dumps(G.to_cx()))
         G.upload_to('http://dev.ndexbio.org', 'scratch', 'scratch')
 
 

--- a/nicecxModel/cx/aspects/CXSimpleAttribute.py
+++ b/nicecxModel/cx/aspects/CXSimpleAttribute.py
@@ -18,62 +18,62 @@ class CXSimpleAttribute():
     def getName(self):
         return self.name
 
-	def setName(self,name):
-		self.name = name
+    def setName(self,name):
+        self.name = name
 
-	def getValue(self):
-		return self.value
+    def getValue(self):
+        return self.value
 
-	def setValue(self, value):
-		self.value = value
+    def setValue(self, value):
+        self.value = value
 
-	def getDataType(self):
-		return self.dataType
+    def getDataType(self):
+        return self.dataType
 
-	def setDataType(self, dataType):
-		self.dataType = dataType
+    def setDataType(self, dataType):
+        self.dataType = dataType
 
 
 '''
-	@JsonProperty("n")
-	private String name;
+    @JsonProperty("n")
+    private String name;
 
-	@JsonProperty("v")
-	private String value;
+    @JsonProperty("v")
+    private String value;
 
-	@JsonProperty("t")
-	private String dataType;
+    @JsonProperty("t")
+    private String dataType;
 
-	public CXSimpleAttribute() {
-	}
+    public CXSimpleAttribute() {
+    }
 
-	public CXSimpleAttribute(NdexPropertyValuePair p ) {
-		name = p.getPredicateString();
-		value = p.getValue();
-		dataType = p.getDataType();
-	}
+    public CXSimpleAttribute(NdexPropertyValuePair p ) {
+        name = p.getPredicateString();
+        value = p.getValue();
+        dataType = p.getDataType();
+    }
 
-	public String get_name() {
-		return name;
-	}
+    public String get_name() {
+        return name;
+    }
 
-	public void set_name(String name) {
-		this.name = name;
-	}
+    public void set_name(String name) {
+        this.name = name;
+    }
 
-	public String getValue() {
-		return value;
-	}
+    public String getValue() {
+        return value;
+    }
 
-	public void setValue(String value) {
-		this.value = value;
-	}
+    public void setValue(String value) {
+        this.value = value;
+    }
 
-	public String getDataType() {
-		return dataType;
-	}
+    public String getDataType() {
+        return dataType;
+    }
 
-	public void setDataType(String dataType) {
-		this.dataType = dataType
+    public void setDataType(String dataType) {
+        this.dataType = dataType
 
 '''

--- a/nicecxModel/tests/fast_test1.py
+++ b/nicecxModel/tests/fast_test1.py
@@ -22,12 +22,12 @@ with open('SIMPLE3.txt', 'rU') as tsvfile:
     #niceCx.create_from_pandas(df, source_field='ChemicalName', target_field='PathwayName', source_node_attr=['Chemical ID (MeSH)'], target_node_attr=['Pathway Source'], edge_attr=[])
     niceCx.create_from_pandas(df)
     #my_cx_json = niceCx.to_cx()
-    print 'nx created'
+    print('nx created')
     niceCx.apply_template('dev2.ndexbio.org', 'scratch', 'scratch', '3daff7cd-9a6b-11e7-9743-0660b7976219')
-    print 'template applied'
+    print('template applied')
 
     niceCx.upload_new_network_stream('dev2.ndexbio.org', 'scratch', 'scratch')
 
     #niceCx.upload_to('dev2.ndexbio.org', 'scratch', 'scratch')
-    print 'Done!'
+    print('Done!')
 

--- a/nicecxModel/tests/test_network_editing.py
+++ b/nicecxModel/tests/test_network_editing.py
@@ -71,13 +71,13 @@ class TestLoadByAspects(unittest.TestCase):
                 node_attr = niceCx.get_node_attribute_object(k, 'NODEATTR')
                 if node_attr:
                     niceCx.set_node_attribute(k, 'NODEATTR', node_attr.get_values() + 'xyz')
-                print node_attr
+                print(node_attr)
 
             for k, v in niceCx.get_edges():
                 edge_attr = niceCx.get_edge_attribute_object(k, 'EDGEATTR')
                 if edge_attr:
                     niceCx.set_edge_attribute(k, 'EDGEATTR', edge_attr.get_values() + 'abc')
-                print edge_attr
+                print(edge_attr)
 
 
             my_cx_json = niceCx.to_cx()


### PR DESCRIPTION
This PR adds configuration for testing with TravisCI. Note that this is not mutually exclusive with CircleCI, and either one can be independently turned on or off as needed on their respective websites. The tests are configured to run on two environments: Python 2.7 and 3.5 so that both are tested. The PR also fixes some small issues with prints and tabs to allow tests to run.