### PR TITLE
Set sphinx theme to sphinx_rtd_theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,7 +87,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'traditional'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
This updates the sphinx theme from the traditional (python2) docs theme to the ReadTheDocs one, which is much more of a community standard. Closes #15