### PR TITLE
Use different strategy for enum install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,9 +75,13 @@ if __name__ == '__main__':
             'urllib3>=1.16',
             'pandas',
             'enum34',
-            'pysolr',
-            'enum; python_version == "2.6" or python_version=="2.7"'
+            'pysolr'
         ],
+
+        extras_require={
+            ':python_version=="2.6"': ['enum'],
+            ':python_version=="2.7"': ['enum']
+            },
 
         include_package_data=True
     )


### PR DESCRIPTION
Fixes #17, I tested ```python setup.py bdist_wheel``` and then `pip install dist/<version>.whl` on both Python 2 and 3, and it works as expected.