### PR TITLE
Update home link and migration of directory creation into get_logger

### DIFF
--- a/ndex2/__init__.py
+++ b/ndex2/__init__.py
@@ -10,16 +10,17 @@ import binascii
 import numpy as np
 from ndex2cx.nice_cx_builder import NiceCXBuilder
 
-root = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-log_path = os.path.join(root, 'logs')
-if not os.path.exists(log_path):
-    os.makedirs(log_path)
 
 node_id_lookup = {}
 edge_id_counter = 0
 
 
 def get_logger(name, level=logging.DEBUG):
+    # TODO Creating a logs directory within the package installation of Python is bad
+    root = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+    log_path = os.path.join(root, 'logs')
+    if not os.path.exists(log_path):
+        os.makedirs(log_path)
     logger = logging.getLogger(name)
     logger.setLevel(level)
 

--- a/ndex2/client.py
+++ b/ndex2/client.py
@@ -2,6 +2,7 @@
 
 import requests
 import json
+import logging
 import ndex2
 from requests_toolbelt import MultipartEncoder
 import io
@@ -10,7 +11,7 @@ import decimal
 import numpy
 import base64
 
-
+logger = logging.getLogger(__name__)
 try:
     from urllib.parse import urljoin
     #from urllib.parse import urlparse
@@ -82,8 +83,8 @@ class Ndex2:
                         self.host = host + "/rest"
 
             except req_except.HTTPError as he:
-                ndex2.get_logger('CLIENT').warning('Can''t determine server version. ' + host +
-                                                   ' Server returned error -- ' + str(he))
+                logger.warning("Can't determine server version. " + host +
+                               ' Server returned error -- ' + str(he))
                 self.version = "1.3"
                 self.host = host + "/rest"
                 # TODO - how to handle errors getting server version...

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
         long_description=long_description,
 
         # The project's main homepage.
-        url='https://www.ndexbio.org',
+        url='https://github.com/ndexbio/ndex2-client',
 
         # Author details
         author='The NDEx Project',


### PR DESCRIPTION
Hi,
Couple changes:

* Switched home page link in setup.py to be the github repo since https://www.ndexbio.org does not work currently. 

 *  In `ndex2/__init__.py` at the top there is code that creates a `logs` directory in the same directory where `ndex2/__init__.py` is installed. This is a problem cause users may not have write access to their Python installation directory and I think I read somewhere it is bad form. This `logs` directory is used by `get_logger()` and since I wasn't sure if anyone was using this I moved the code under that function. I converted the only call to that function from `ndex2/client.py` to use `logger.warning()`