### PR TITLE
Syntax fix

### DIFF
--- a/ndex2/nice_cx_network.py
+++ b/ndex2/nice_cx_network.py
@@ -1891,7 +1891,7 @@ class NiceCXNetwork:
         consistency_group = 1
         if self.metadata_original is not None:
             for mi in self.metadata_original:
-                if mi.get("consistencyGroup" is not None):
+                if mi.get("consistencyGroup") is not None:
                     if mi.get("consistencyGroup") > consistency_group:
                         consistency_group = mi.get("consistencyGroup")
                 else:


### PR DESCRIPTION
Hello,

I spotted a syntax warning in one of our projects that has your project as a dependency.
```
ndex2/nice_cx_network.py:1894: SyntaxWarning: "is not" with a literal. Did you mean "!="?
```

Took the liberty of correcting it. Feel free to merge or ignore.