### PR TITLE
Fix typo in generate_metadata()

### DIFF
--- a/ndex2/nice_cx_network.py
+++ b/ndex2/nice_cx_network.py
@@ -1891,7 +1891,7 @@ class NiceCXNetwork:
         consistency_group = 1
         if self.metadata_original is not None:
             for mi in self.metadata_original:
-                if mi.get("consistencyGroup" is not None):
+                if mi.get("consistencyGroup") is not None:
                     if mi.get("consistencyGroup") > consistency_group:
                         consistency_group = mi.get("consistencyGroup")
                 else:


### PR DESCRIPTION
This PR fixes a typo in the order of parentheses. Before, this code would check the string literal is not none, which is always `True`, then pass that into `mi.get(True)`. Now, this is fixed