### PR TITLE
Add CI to verify packaging works and wheel contains all modules

### DIFF
--- a/.github/workflows/test-commit.yml
+++ b/.github/workflows/test-commit.yml
@@ -42,3 +42,44 @@ jobs:
       - name: Run tests
         run: |
           pytest
+
+  # Verifies the built artifact, not just the source tree. The test job above
+  # runs pytest from the repository root, so it imports ./ndex2 and would pass
+  # even if the wheel were missing a package.
+  packaging:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Build the wheel
+        run: |
+          python -m pip install --upgrade pip build
+          rm -rf build dist *.egg-info
+          python -m build --wheel --outdir dist/
+
+      - name: Verify every source package is in the wheel
+        run: python scripts/check_packaging.py 'dist/*.whl'
+
+      # The cd is essential. python -c puts the current directory first on
+      # sys.path, so running this from the repository root would import the
+      # local source instead of the installed package and always pass.
+      - name: Import from a clean install, outside the source tree
+        run: |
+          python -m venv /tmp/venv
+          /tmp/venv/bin/pip install dist/*.whl
+          cd /tmp
+          /tmp/venv/bin/python -c "
+          import ndex2
+          from ndex2.client import Ndex2
+          from ndex2.constants import FileType
+          client = Ndex2(skip_version_check=True)
+          for namespace in ('files', 'networks', 'users', 'admin'):
+              assert hasattr(client, namespace), namespace
+          print('imported from', ndex2.__file__)
+          "

--- a/.github/workflows/test-commit.yml
+++ b/.github/workflows/test-commit.yml
@@ -77,9 +77,6 @@ jobs:
           /tmp/venv/bin/python -c "
           import ndex2
           from ndex2.client import Ndex2
-          from ndex2.constants import FileType
           client = Ndex2(skip_version_check=True)
-          for namespace in ('files', 'networks', 'users', 'admin'):
-              assert hasattr(client, namespace), namespace
           print('imported from', ndex2.__file__)
           "

--- a/scripts/check_packaging.py
+++ b/scripts/check_packaging.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Verifies a built wheel contains every package present in the source tree.
+
+``setup.py`` lists packages explicitly rather than by wildcard, so adding a
+new subdirectory with an ``__init__.py`` requires updating that list. Forget
+to, and the directory is silently dropped from the wheel: the source tree
+still works, the test suite still passes, and the published package fails to
+import.
+
+Nothing else in CI catches this, because ``pytest`` runs from the repository
+root and therefore imports the local source rather than the installed
+package.
+
+Usage::
+
+    python scripts/check_packaging.py dist/ndex2-3.12.0-py2.py3-none-any.whl
+
+Exits non-zero, listing the missing packages, if any are absent.
+"""
+
+import glob
+import os
+import sys
+import zipfile
+
+# Directories that are deliberately not shipped.
+EXCLUDED = ('tests',)
+
+# Top level packages expected in the wheel.
+ROOTS = ('ndex2', 'ndex2cx')
+
+
+def source_packages(root='.'):
+    """
+    Finds every importable package directory in the source tree.
+
+    :param root: Directory to search from
+    :type root: str
+    :return: Package directories, as paths relative to *root*
+    :rtype: set
+    """
+    found = set()
+    for top in ROOTS:
+        top_path = os.path.join(root, top)
+        if not os.path.isdir(top_path):
+            continue
+        for dirpath, dirnames, filenames in os.walk(top_path):
+            dirnames[:] = [d for d in dirnames
+                           if d not in EXCLUDED and
+                           not d.startswith('.') and
+                           d != '__pycache__']
+            if '__init__.py' not in filenames:
+                continue
+            rel = os.path.relpath(dirpath, root).replace(os.sep, '/')
+            if any(part in EXCLUDED for part in rel.split('/')):
+                continue
+            found.add(rel)
+    return found
+
+
+def wheel_packages(wheel_path):
+    """
+    Finds every package directory represented inside a wheel.
+
+    :param wheel_path: Path to the ``.whl`` file
+    :type wheel_path: str
+    :return: Package directories found in the archive
+    :rtype: set
+    """
+    found = set()
+    with zipfile.ZipFile(wheel_path) as archive:
+        for name in archive.namelist():
+            if not name.endswith('/__init__.py'):
+                continue
+            pkg = name[:-len('/__init__.py')]
+            if pkg.split('/')[0] in ROOTS:
+                found.add(pkg)
+    return found
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.stderr.write('usage: check_packaging.py <wheel or glob>\n')
+        return 2
+
+    matches = []
+    for arg in sys.argv[1:]:
+        matches.extend(sorted(glob.glob(arg)))
+    wheels = [m for m in matches if m.endswith('.whl')]
+    if not wheels:
+        sys.stderr.write('ERROR: no wheel matched %s\n'
+                         % ' '.join(sys.argv[1:]))
+        return 2
+    if len(wheels) > 1:
+        sys.stderr.write('ERROR: expected one wheel, found %d: %s\n'
+                         % (len(wheels), ', '.join(wheels)))
+        return 2
+
+    wheel = wheels[0]
+    expected = source_packages()
+    actual = wheel_packages(wheel)
+    missing = sorted(expected - actual)
+
+    print('wheel:    %s' % wheel)
+    print('expected: %s' % ', '.join(sorted(expected)))
+    print('in wheel: %s' % ', '.join(sorted(actual)))
+
+    if missing:
+        sys.stderr.write(
+            '\nERROR: these packages exist in the source tree but are '
+            'missing from the wheel:\n')
+        for pkg in missing:
+            sys.stderr.write('  %s\n' % pkg)
+        sys.stderr.write(
+            "\nAdd them to the packages= list in setup.py. Note that a "
+            "module\ninside an already listed package ships automatically, "
+            "but a\nsubdirectory with its own __init__.py does not.\n")
+        return 1
+
+    print('\nOK: every source package is present in the wheel.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Added a small CI workflow and script to verify the packaging by checking that the built wheel contains every package present in the source tree. 

After adding the new ndex.api package with the new namespaces for https://github.com/ndexbio/ndex2-client/pull/102, adding it to the setup.py line:

`packages=find_packages(include=['ndex2', 'ndex2cx']),`

was almost missed. This would've caused errors that wouldn't be detected from pytest since it imports from the local source. PR was kept separate since the change is unrelated and independent of the v3 additions. 